### PR TITLE
Remove requirement for authentication when using a pubsub emulator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/otel v1.0.1
-	go.opentelemetry.io/otel/sdk v1.0.1
 	go.opentelemetry.io/otel/trace v1.0.1
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,6 @@ go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opentelemetry.io/otel v1.0.1 h1:4XKyXmfqJLOQ7feyV5DB6gsBFZ0ltB8vLtp6pj4JIcc=
 go.opentelemetry.io/otel v1.0.1/go.mod h1:OPEOD4jIT2SlZPMmwT6FqZz2C0ZNdQqiWcoK6M0SNFU=
-go.opentelemetry.io/otel/sdk v1.0.1 h1:wXxFEWGo7XfXupPwVJvTBOaPBC9FEg0wB8hMNrKk+cA=
-go.opentelemetry.io/otel/sdk v1.0.1/go.mod h1:HrdXne+BiwsOHYYkBE5ysIcv2bvdZstxzmCQhxTcZkI=
 go.opentelemetry.io/otel/trace v1.0.1 h1:StTeIH6Q3G4r0Fiw34LTokUFESZgIDUr0qIJ7mKmAfw=
 go.opentelemetry.io/otel/trace v1.0.1/go.mod h1:5g4i4fKLaX2BQpSBsxw8YYcgKpMMSW3x7ZTuYBr3sUk=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
@@ -496,7 +494,6 @@ golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	fmt "fmt"
 	math "math"
+	"os"
 	"runtime"
 	"sync"
 	"time"
@@ -48,12 +49,20 @@ func NewGoogleCloud(projectID string) (*GoogleCloud, error) {
 		numConns = 4
 	}
 
-	c, err := pubsub.NewClient(context.Background(), projectID, option.WithGRPCConnectionPool(numConns))
+	oo := []option.ClientOption{
+		option.WithGRPCConnectionPool(numConns),
+	}
+
+	if os.Getenv("PUBSUB_EMULATOR_HOST") != "" {
+		oo = append(oo, option.WithoutAuthentication())
+	}
+
+	c, err := pubsub.NewClient(context.Background(), projectID, oo...)
 	if err != nil {
 		return nil, err
 	}
 
-	s, err := pbs.NewSubscriberClient(context.Background(), option.WithGRPCConnectionPool(numConns))
+	s, err := pbs.NewSubscriberClient(context.Background(), oo...)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -3,6 +3,7 @@ package google
 import (
 	"context"
 	fmt "fmt"
+	"google.golang.org/grpc"
 	math "math"
 	"os"
 	"runtime"
@@ -55,6 +56,7 @@ func NewGoogleCloud(projectID string) (*GoogleCloud, error) {
 
 	if os.Getenv("PUBSUB_EMULATOR_HOST") != "" {
 		oo = append(oo, option.WithoutAuthentication())
+		oo = append(oo, option.WithGRPCDialOption(grpc.WithInsecure()))
 	}
 
 	c, err := pubsub.NewClient(context.Background(), projectID, oo...)


### PR DESCRIPTION
#### What does this PR do?
For local development we need to be able to point services at an emulated pubsub container. This container doesn't have any authentication so we need to remove the requirement for it when setting up our grpc clients.

This change hooks into the `PUBSUB_EMULATOR_HOST` env var override used inside the google pub sub pkgs to set up options to remove authentication. This removed the requirement of a `credentials.json` on services when running with this env var set.

Related vid of local pubsub in minikube when using this change on a branch.

https://user-images.githubusercontent.com/102029122/200582070-a0b8e964-0b99-4d13-88ee-85c13adba9d0.mov



